### PR TITLE
WIP: Initial Keycloak / APIMan Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you're making changes, and you'd like to rebuild and launch the full stack,
 the safest way to do so is with:
 
 ```
-docker-compose rm -vfa configr apiman && docker-compose build --no-cache configr apiman && docker-compose u
+docker-compose rm -vfa configr apiman && docker-compose build --no-cache configr apiman && docker-compose up
 ```
 
 This will guarantee that old containers (and their data) are removed, and new ones are build from scratch.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,27 @@ This project is intended to be run from [`hmda-platform`](https://github.com/cfp
 Docker Compose setup, configured in [`hmda-platform/docker-compose.yml`](https://github.com/cfpb/hmda-platform/blob/master/docker-compose.yml).
 Please see the instructions in that repo for details on how to launch the system.
 
+## Run it!
+
+### First Time
+
+When you are launching this stack from a clean slate, all you need is a simple:
+
+```
+docker-compose up
+```
+
+### Re-running
+
+If you're making changes, and you'd like to rebuild and launch the full stack, 
+the safest way to do so is with:
+
+```
+docker-compose rm -vfa configr apiman && docker-compose build --no-cache configr apiman && docker-compose u
+```
+
+This will guarantee that old containers (and their data) are removed, and new ones are build from scratch.
+
 ## Known issues
 
 The `configr` provisioning tool currently only works from a clean install.  Subsequent runs of `configr` against fully provisioned

--- a/README.md
+++ b/README.md
@@ -1,46 +1,35 @@
-
-
 # HMDA Platform Auth
 
-### This project is a work in progress.
+This is a prototype for providing [OpenID Connect](http://openid.net/connect/)-based
+authentication and authorization services for all HMDA APIs and web applications 
+with identity requirements.  This is currently implemented to support the 
+[`hmda-platform`](https://github.com/cfpb/hmda-platform) and 
+[`hmda-platform-ui`](https://github.com/cfpb/hmda-platform-ui) projects,
+though may support more in the future.
 
-Information and code contained in this repository should be considered provisional and a work in progress, and not the final implementation for the HMDA Platform Auth components, unless otherwise indicated.
+## Technologies
 
-## Introduction to HMDA
-
-The Home Mortgage Disclosure Act (HMDA) requires many financial institutions to maintain, report, and publicly disclose information about mortgages. HMDA was originally enacted by Congress in 1975 and is implemented by Regulation C. The Dodd-Frank Act transferred HMDA rulemaking authority from the Federal Reserve Board to the Consumer Financial Protection Bureau (CFPB) on July 21, 2011.
-
-This regulation provides the public loan data that can be used to assist:
-
-- in determining whether financial institutions are serving the housing needs of their communities;
-- public officials in distributing public-sector investments so as to attract private investment to areas where it is needed;
-- and in identifying possible discriminatory lending patterns.
-
-This regulation applies to certain financial institutions, including banks, savings associations, credit unions, and other mortgage lending institutions.
-
-For more information on HMDA, please visit: [http://www.consumerfinance.gov/data-research/hmda/](http://www.consumerfinance.gov/data-research/hmda/) at the Consumer Financial Protection Bureau. 
-
-## The Platform Auth
-
-This repo is supporting components for the  [HMDA platform back-end](https://github.com/cfpb/hmda-platform) and the [HMDA platform UI](https://github.com/cfpb/hmda-platform-ui). 
-
-The various parts of the platform auth are: TBD
+* [Keycloak](http://www.keycloak.org/) - Open-source identity management, with full OpenID Connect support.
+* [APIMan](http://www.apiman.io/latest/) - Open-source API management, abstracting OpenID Connect details from underlying APIs.
+* [Python 3](https://docs.python.org/3/) - Used for provisioning Keycloak and APIMan instances.
 
 ## Dependencies
 
-TBD
+This project has been fully Docker-ized.  Docker is all you need to launch the full stack!
+
+* [Docker](https://www.docker.com/)
+* [Docker Compose](https://docs.docker.com/compose/)
 
 ## Installation
 
-TBD
-
-## How to test the software
-
-TBD
+This project is intended to be run from [`hmda-platform`](https://github.com/cfpb/hmda-platform)'s
+Docker Compose setup, configured in [`hmda-platform/docker-compose.yml`](https://github.com/cfpb/hmda-platform/blob/master/docker-compose.yml).
+Please see the instructions in that repo for details on how to launch the system.
 
 ## Known issues
 
-This repo is a work in progress.
+The `configr` provisioning tool currently only works from a clean install.  Subsequent runs of `configr` against fully provisioned
+systems will fail.
 
 ## Getting help
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,19 +4,26 @@ services:
   apiman:
     build: ./docker/apiman
     ports:
-      - '80:9080'
-      - '443:9443'
-      - '9990:9990'
+      - '9080:8080'
+      - '9443:8443'
+    links:
+      - api
+      - echo 
 
   configr:
     build: ./docker/configr
 
+  echo:
+    build: ./docker/echo-api
+    ports:
+      - '5000:5000'
+
   api:
     build: ../hmda-platform
-    ports:
-      - '8080:8080'
 
   web:
     build: ../hmda-platform-ui
     ports:
       - '80:80'
+    depends_on:
+      - configr

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,22 @@
+version: '2'
+services:
+
+  apiman:
+    build: ./docker/apiman
+    ports:
+      - '80:9080'
+      - '443:9443'
+      - '9990:9990'
+
+  configr:
+    build: ./docker/configr
+
+  api:
+    build: ../hmda-platform
+    ports:
+      - '8080:8080'
+
+  web:
+    build: ../hmda-platform-ui
+    ports:
+      - '80:80'

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,6 @@
+# Docker Images
+
+The following directories contain the `Dockerfile`s and corresponding artifacts 
+needed to build the Docker images used in the project.  Each directory should have
+it's own README describing the intent of the Docker image, and examples of how
+to run it.

--- a/docker/apiman/Dockerfile
+++ b/docker/apiman/Dockerfile
@@ -1,0 +1,4 @@
+FROM apiman/on-wildfly10:1.2.7.Final
+
+#COPY ./keycloak/configuration/keycloak-server.json:/opt/jboss/wildfly/standalone/configuration/keycloak-server.json
+COPY ./keycloak/ /opt/jboss/wildfly/standalone/

--- a/docker/apiman/Dockerfile
+++ b/docker/apiman/Dockerfile
@@ -1,4 +1,5 @@
 FROM apiman/on-wildfly10:1.2.7.Final
 
-#COPY ./keycloak/configuration/keycloak-server.json:/opt/jboss/wildfly/standalone/configuration/keycloak-server.json
-COPY ./keycloak/ /opt/jboss/wildfly/standalone/
+WORKDIR /opt/jboss/wildfly
+
+#COPY ./keycloak/configuration/keycloak-server.json standalone/configuration/keycloak-server.json

--- a/docker/apiman/README.md
+++ b/docker/apiman/README.md
@@ -1,0 +1,7 @@
+# APIMan / Keycloak Docker Image
+
+The following `Dockerfile` builds a combined APIMan / Keycloak image based on
+the official APIMan image ([`apiman/on-wildfly10`](https://hub.docker.com/r/apiman/on-wildfly10/)).
+
+In addition, this `Dockerfile` overrides the default Keycloak configuration, and
+copies in customized web templates.

--- a/docker/apiman/keycloak/configuration/keycloak-server.json
+++ b/docker/apiman/keycloak/configuration/keycloak-server.json
@@ -1,0 +1,76 @@
+{
+    "providers": [
+        "classpath:${jboss.home.dir}/providers/*"
+    ],
+
+    "admin": {
+        "realm": "master"
+    },
+
+    "eventsStore": {
+        "provider": "jpa",
+        "jpa": {
+            "exclude-events": [ "REFRESH_TOKEN" ]
+        }
+    },
+
+    "realm": {
+        "provider": "jpa"
+    },
+
+    "user": {
+        "provider": "jpa"
+    },
+
+    "userCache": {
+        "default" : {
+            "enabled": true
+        }
+    },
+
+    "userSessionPersister": {
+        "provider": "jpa"
+    },
+
+    "timer": {
+        "provider": "basic"
+    },
+
+    "theme": {
+        "staticMaxAge": 2592000,
+        "cacheTemplates": false,
+        "cacheThemes": false,
+        "folder": {
+          "dir": "${jboss.home.dir}/themes"
+        }
+    },
+
+    "scheduled": {
+        "interval": 900
+    },
+
+    "connectionsHttpClient": {
+        "default": {}
+    },
+
+    "connectionsJpa": {
+        "default": {
+            "dataSource": "java:jboss/datasources/KeycloakDS",
+            "databaseSchema": "update"
+        }
+    },
+
+    "realmCache": {
+        "provider": "default",
+        "default" : {
+            "enabled": true
+        }
+    },
+
+    "connectionsInfinispan": {
+        "provider": "default",
+        "default": {
+            "cacheContainer" : "java:comp/env/infinispan/Keycloak"
+        }
+    }
+}

--- a/docker/configr/Dockerfile
+++ b/docker/configr/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.5-onbuild
+
+CMD ./config.py

--- a/docker/configr/README.md
+++ b/docker/configr/README.md
@@ -1,0 +1,27 @@
+# `configr` Docker Image
+
+This is a custom Python-based tool used for initializing
+Keycloak and APIMan based on hmda-platform's needs.  This is
+necessary because both Keycloak's and APIMan's built-in
+config-on-startup are not-so-great in their own special way.
+
+In addition, we're using APIMan's Keycloak plugin, which 
+requires exchanging certificates generated at Keycloak 
+initialization, which makes using a static configuration for
+APIMan infeasable.
+
+## Known Issues
+
+* `config` can only be executed once.  If you attempt to apply
+    changes to a configured system, it will fail.  If we decided
+    to keep this as our configuration tool, we'll have to fix this.
+
+* Docker Compose doesn't seem to be smart enough to rebuild this
+    image when you change the underlying Python script or config file,
+    so you must force it.  The following will force a rebuild of both
+    `configr` and `apiman` services, which is the general workflow when
+    tweaking the script.
+
+    ```
+    docker-compose rm -vfa configr apiman && docker-compose build --no-cache configr && docker-compose up
+    ```

--- a/docker/configr/config.py
+++ b/docker/configr/config.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+Configures Keycloak and APIMan services
+"""
+
+import json
+from pprint import pprint
+import requests
+import time
+import yaml
+
+class OidcRestClient(object):
+    """
+    REST API client for Keycloak and APIMan, handling the
+    OpenID Connect handshake consistently.
+    """
+
+    def __init__(self, base_url, authz_server_url, username, password, client_id):
+        self.base_url = base_url
+
+        oidc_req_data = {
+            'username': username,
+            'password': password,
+            'grant_type': 'password',
+            'client_id': client_id,
+        }
+
+        oidc_resp = requests.post(
+            authz_server_url,
+            data=oidc_req_data
+        )
+        oidc_resp.raise_for_status()
+
+        access_token = oidc_resp.json()['access_token']
+        self.authz_header = {'Authorization': 'Bearer {}'.format(access_token)}
+
+
+    def request(self, method, resource, json=None):
+        url = '{}/{}'.format(self.base_url, resource)
+        resp = requests.request(method, url, json=json, headers=self.authz_header)
+
+        resp.raise_for_status()
+
+        return resp
+        
+
+def sync_keycloak(config, keycloak_client):
+
+    realms_url = 'realms'
+    realms = config['keycloak']['realms']
+    realm_certs = {}
+
+    for realm in realms:
+        clients = realm.pop('clients')
+        realm_id = realm['realm']
+    
+        realms_resp = keycloak_client.request('POST', realms_url, json=realm)
+    
+        realm_url = '{}/{}'.format(realms_url, realm_id)
+        realm_resp = keycloak_client.request('GET', realm_url)
+        realm_cert = realm_resp.json()['certificate']
+    
+        # Map certs to their realm.  Needed later by APIMan
+        realm_certs[realm_id] = realm_cert
+
+        print('Added Keycloak realm "{}"'.format(realm_id))
+    
+        for client in clients:
+            mappers = client.pop('protocolMappers')
+            client_id = client['clientId']
+            clients_url = '{}/clients'.format(realm_url, realm_id)
+            client_resp = keycloak_client.request('POST', clients_url, json=client)
+
+            # Get the client GUID off the URL of the newly created client
+            client_guid = client_resp.headers['Location'].split('/')[-1]
+            client_url = '{}/{}'.format(clients_url, client_guid)
+
+            print('Added Keycloak client "{}" ({}) to realm "{}"'.format(client_id, client_guid, realm_id))
+
+            for mapper in mappers:
+                mapper_id = mapper['name']
+                mappers_url = '{}/protocol-mappers/models'.format(client_url)
+                mapper_resp = keycloak_client.request('POST', mappers_url, json=mapper)
+
+                print('Added Keycloak protocol mapper "{}" to client "{}"'.format(mapper_id, client_id))
+
+    return realm_certs
+
+
+def sync_gateways(gateways, apiman_client):
+    for gateway in gateways:
+        
+        gateway_id = gateway.pop('id')
+        gateway.pop('name')
+    
+        gateway_cfg_str = json.dumps(gateway['configuration'])
+        gateway['configuration'] = gateway_cfg_str
+    
+        gateway_url = 'gateways/{}'.format(gateway_id)
+        gateway_resp = apiman_client.request('PUT', gateway_url, json=gateway)
+    
+        print('Updated APIMan gateway "{}"'.format(gateway_id))
+
+
+def sync_plugins(plugins, apiman_client):
+    for plugin in plugins:
+        plugin_id = plugin['artifactId']
+        plugin_resp = apiman_client.request('POST', 'plugins', json=plugin)
+
+        print('Added APIMan plugin "{}"'.format(plugin))
+
+
+def sync_orgs(orgs, apiman_client, realm_certs):
+    orgs_url = 'organizations'
+
+    for org in orgs:
+        org_id = org['name']
+        apis_url = '{}/{}/apis'.format(orgs_url, org_id)
+        apis = org.pop('apis')
+
+        org_resp = apiman_client.request('POST', orgs_url, json=org)
+
+        print('Added APIMan Org "{}"'.format(org_id))
+ 
+        for api in apis:
+            api_id = api['name']
+            versions_url = '{}/{}/versions'.format(apis_url, api_id)
+            versions = api.pop('versions')
+
+            api_resp = apiman_client.request('POST', apis_url, json=api)
+
+            print('Added APIMan API "{}" to "{}"'.format(api_id, org_id))
+
+            for version in versions:
+                version_id = version['version']
+                policies_url = '{}/{}/policies'.format(versions_url, version_id)
+                policies = version.pop('policies')
+
+                version_resp = apiman_client.request('POST', versions_url, json=version)
+
+                print('Added APIMan version "{}" to API "{}:{}"'.format(version_id, org_id, api_id))
+
+                for policy in policies:
+                    policy_def = policy['definitionId']
+                    pol_cfg = policy['configuration']
+                    
+                    if(policy_def == 'keycloak-oauth-policy'):
+                        # Get realm name from tail of realm url
+                        realm_name = pol_cfg['realm'].split('/')[-1]
+
+                        # Get the Keycloak cert for a given realm
+                        pol_cfg['realmCertificateString'] = realm_certs[realm_name]
+
+                    # Flatten `configuration` into a json string
+                    policy['configuration'] = json.dumps(pol_cfg)
+
+                    pol_resp = apiman_client.request('POST', policies_url, json=policy)
+
+                    print('Added APIMan policy "{}" to {}:{}:{}'.format(
+                        policy_def, org_id, api_id, version_id
+                    ))
+
+                # Publish API Version
+                action = {
+                    'type': 'publishAPI',
+                    'entityId': api_id, 
+                    'entityVersion': version_id,
+                    'organizationId': org_id
+                }
+
+                pub_resp = apiman_client.request('POST', 'actions', json=action)
+
+                print('Published API {}:{}:{}'.format(org_id, api_id, version_id))
+
+
+# Sync apiman data
+def sync_apiman(config, apiman_client, realm_certs):
+    apiman = config['apiman']
+
+    sync_gateways(apiman['gateways'], apiman_client)
+    sync_plugins(apiman['plugins'], apiman_client)
+    sync_orgs(apiman['organizations'], apiman_client, realm_certs)
+
+def is_up(service_name, url):
+    """
+    Waits for a given URL to respond with an acceptable
+    HTTP status code(s)
+    """
+
+    from requests.exceptions import ConnectionError, HTTPError
+    from json.decoder import JSONDecodeError
+
+    # Wait for APIMan to be available
+    while True:
+        try:
+            is_up_resp = requests.get(url)
+            is_up_resp.raise_for_status()
+            print('{} is up at {}'.format(service_name, url))
+            break
+        #except NewConnectionError as nce:
+        except (ConnectionError, HTTPError, JSONDecodeError) as ce:
+            print('Waiting for {} at {}...'.format(service_name, url))
+            #print(ce)
+            time.sleep(5)
+
+def main():
+
+    #FIXME: Pass these in a params
+    username = 'admin'
+    password = 'admin123!'
+    root_url = 'http://192.168.99.100'
+    
+    # Setup base URLs
+    keycloak_base_url = '{}/auth'.format(root_url)
+    keycloak_api_url = '{}/admin'.format(keycloak_base_url)
+    apiman_api_url = '{}/apiman'.format(root_url)
+
+    # Make sure Keycloak and APIMan are fully up first
+    is_up('APIMan', apiman_api_url)
+    is_up('Keycloak', '{}/realms/master'.format(keycloak_base_url))
+
+    keycloak_client = OidcRestClient(
+        keycloak_api_url,
+        '{}/realms/master/protocol/openid-connect/token'.format(keycloak_base_url),
+        username,
+        password,
+        'admin-cli'
+    )
+    
+    apiman_client = OidcRestClient(
+        apiman_api_url,
+        '{}/realms/apiman/protocol/openid-connect/token'.format(keycloak_base_url),
+        username,
+        password,
+        'apiman'
+    )
+
+    # Read in config.yaml
+    config = None
+    
+    with open('config.yaml') as config_file:
+        config = yaml.load(config_file)
+
+    # Configure Keycloak and APIMan based on config.yaml
+    realm_certs = sync_keycloak(config, keycloak_client)
+    sync_apiman(config, apiman_client, realm_certs)
+
+    #client_resp = keycloak_client.request('GET', 'realms/hmda/clients/')
+    #pprint(client_resp.json())
+
+if __name__ == "__main__":
+    main()

--- a/docker/configr/config.py
+++ b/docker/configr/config.py
@@ -208,7 +208,7 @@ def main():
     #FIXME: Pass these in a params
     username = 'admin'
     password = 'admin123!'
-    root_url = 'http://192.168.99.100'
+    root_url = 'http://192.168.99.100:9080'
     
     # Setup base URLs
     keycloak_base_url = '{}/auth'.format(root_url)

--- a/docker/configr/config.yaml
+++ b/docker/configr/config.yaml
@@ -133,4 +133,73 @@ apiman:
                       - POST
                       - PUT
                     maxAge: 600
+        - name: echo 
+          description: 'Echo API'
+          versions:
+            - version: v1
+              endpoint: 'http://echo:5000'
+              endpointType: rest
+              endpointContentType: json
+              publicAPI: true
+              policies:
+                - definitionId: cors-policy
+                  configuration:
+                    errorOnCorsFailure: true
+                    allowOrigin:
+                      - 'http://192.168.99.100'
+                    allowCredentials: false
+                    exposeHeaders: []
+                    allowHeaders:
+                      - Authorization
+                      - Accept
+                    allowMethods:
+                      - DELETE
+                      - GET
+                      - HEAD
+                      - OPTIONS
+                      - PATCH
+                      - POST
+                      - PUT
+                    maxAge: 600
+                - definitionId: keycloak-oauth-policy
+                  configuration:
+                    requireOauth: true
+                    requireTransportSecurity: true
+                    blacklistUnsafeTokens: false
+                    stripTokens: false
+                    realm: 'https://192.168.99.100:9443/auth/realms/hmda'
+                    realmCertificateString: null
+                    forwardRoles: 
+                      active: false
+                    delegateKerberosTicket: false
+                    forwardAuthInfo:
+                      - headers: CFPB-HMDA-Institutions
+                        field: institutions
+                      - headers: CFPB-HMDA-Username
+                        field: preferred_username
+            - version: noauth 
+              endpoint: 'http://echo:5000'
+              endpointType: rest
+              endpointContentType: json
+              publicAPI: true
+              policies:
+                - definitionId: cors-policy
+                  configuration:
+                    errorOnCorsFailure: true
+                    allowOrigin:
+                      - 'http://192.168.99.100'
+                    allowCredentials: false
+                    exposeHeaders: []
+                    allowHeaders:
+                      - Authorization
+                      - Accept
+                    allowMethods:
+                      - DELETE
+                      - GET
+                      - HEAD
+                      - OPTIONS
+                      - PATCH
+                      - POST
+                      - PUT
+                    maxAge: 600
 

--- a/docker/configr/config.yaml
+++ b/docker/configr/config.yaml
@@ -1,0 +1,136 @@
+keycloak:
+  realms:
+    - realm: hmda
+      enabled: true
+      sslRequired: external
+      registrationAllowed: true
+      registrationEmailAsUsername: true
+      rememberMe: false
+      verifyEmail: false
+      loginTheme: hmda
+      clients:
+        - clientId: hmda-apis 
+          surrogateAuthRequired: false
+          enabled: true
+          clientAuthenticatorType: client-secret
+          rootUrl: null
+          baseUrl: 'http://192.168.99.100:3000'
+          redirectUris:
+            - 'http://192.168.99.100:3000'
+            - 'http://192.168.99.100:3000/*'
+          webOrigins:
+            - 'http://192.168.99.100:3000'
+          notBefore: 0
+          bearerOnly: false
+          consentRequired: false
+          standardFlowEnabled: false
+          implicitFlowEnabled: true
+          directAccessGrantsEnabled: false
+          serviceAccountsEnabled: false
+          publicClient: true
+          frontchannelLogout: false
+          protocol: openid-connect
+          protocolMappers:
+            - name: institutions
+              protocol: openid-connect
+              protocolMapper: oidc-usermodel-attribute-mapper
+              consentRequired: false
+              config: 
+                access.token.claim: true
+                claim.name: institutions
+                id.token.claim: true
+                jsonType.label: String
+                user.attribute: institutions
+              
+apiman:
+  gateways:
+    - id: TheGateway
+      name: The Gateway
+      description: This is the gateway
+      type: REST
+      configuration:
+        endpoint: 'https://192.168.99.100/apiman-gateway-api'
+        # Default username/password
+        username: 'apimanager'
+        password: 'apiman123!'
+  plugins:
+    - groupId: io.apiman.plugins
+      artifactId: apiman-plugins-cors-policy
+      version: 1.2.7.Final
+    - groupId: io.apiman.plugins
+      artifactId: apiman-plugins-keycloak-oauth-policy
+      version: 1.2.7.Final
+  organizations:
+    - name: hmda
+      description: All-things-HMDA
+      apis:
+        - name: hmda-platform
+          description: 'HMDA Platform API'
+          versions:
+            - version: v1
+              endpoint: 'http://192.168.99.100:8080'
+              endpointType: rest
+              endpointContentType: json
+              publicAPI: true
+              policies:
+                - definitionId: cors-policy
+                  configuration:
+                    errorOnCorsFailure: true
+                    allowOrigin:
+                      - 'http://192.168.99.100:3000'
+                    allowCredentials: false
+                    exposeHeaders: []
+                    allowHeaders:
+                      - Authorization
+                      - Accept
+                    allowMethods:
+                      - DELETE
+                      - GET
+                      - HEAD
+                      - OPTIONS
+                      - PATCH
+                      - POST
+                      - PUT
+                    maxAge: 600
+                - definitionId: keycloak-oauth-policy
+                  configuration:
+                    requireOauth: true
+                    requireTransportSecurity: true
+                    blacklistUnsafeTokens: false
+                    stripTokens: false
+                    realm: 'http://192.168.99.100/auth/realms/hmda'
+                    realmCertificateString: null 
+                    forwardRoles: 
+                      active: false
+                    delegateKerberosTicket: false
+                    forwardAuthInfo:
+                      - headers: CFPB-HMDA-Institutions
+                        field: institutions
+                      - headers: CFPB-HMDA-Username
+                        field: preferred_username
+            - version: noauth 
+              endpoint: 'http://192.168.99.100:8080'
+              endpointType: rest
+              endpointContentType: json
+              publicAPI: true
+              policies:
+                - definitionId: cors-policy
+                  configuration:
+                    errorOnCorsFailure: true
+                    allowOrigin:
+                      - 'http://192.168.99.100:3000'
+                    allowCredentials: false
+                    exposeHeaders: []
+                    allowHeaders:
+                      - Authorization
+                      - Accept
+                    allowMethods:
+                      - DELETE
+                      - GET
+                      - HEAD
+                      - OPTIONS
+                      - PATCH
+                      - POST
+                      - PUT
+                    maxAge: 600
+

--- a/docker/configr/config.yaml
+++ b/docker/configr/config.yaml
@@ -14,12 +14,12 @@ keycloak:
           enabled: true
           clientAuthenticatorType: client-secret
           rootUrl: null
-          baseUrl: 'http://192.168.99.100:3000'
+          baseUrl: 'http://192.168.99.100'
           redirectUris:
-            - 'http://192.168.99.100:3000'
-            - 'http://192.168.99.100:3000/*'
+            - 'http://192.168.99.100'
+            - 'http://192.168.99.100/*'
           webOrigins:
-            - 'http://192.168.99.100:3000'
+            - 'http://192.168.99.100'
           notBefore: 0
           bearerOnly: false
           consentRequired: false
@@ -49,7 +49,7 @@ apiman:
       description: This is the gateway
       type: REST
       configuration:
-        endpoint: 'https://192.168.99.100/apiman-gateway-api'
+        endpoint: 'https://192.168.99.100:9443/apiman-gateway-api'
         # Default username/password
         username: 'apimanager'
         password: 'apiman123!'
@@ -68,7 +68,7 @@ apiman:
           description: 'HMDA Platform API'
           versions:
             - version: v1
-              endpoint: 'http://192.168.99.100:8080'
+              endpoint: 'http://api:8080'
               endpointType: rest
               endpointContentType: json
               publicAPI: true
@@ -77,7 +77,7 @@ apiman:
                   configuration:
                     errorOnCorsFailure: true
                     allowOrigin:
-                      - 'http://192.168.99.100:3000'
+                      - 'http://192.168.99.100'
                     allowCredentials: false
                     exposeHeaders: []
                     allowHeaders:
@@ -98,7 +98,7 @@ apiman:
                     requireTransportSecurity: true
                     blacklistUnsafeTokens: false
                     stripTokens: false
-                    realm: 'http://192.168.99.100/auth/realms/hmda'
+                    realm: 'https://192.168.99.100:9443/auth/realms/hmda'
                     realmCertificateString: null 
                     forwardRoles: 
                       active: false
@@ -109,7 +109,7 @@ apiman:
                       - headers: CFPB-HMDA-Username
                         field: preferred_username
             - version: noauth 
-              endpoint: 'http://192.168.99.100:8080'
+              endpoint: 'http://api:8080'
               endpointType: rest
               endpointContentType: json
               publicAPI: true
@@ -118,7 +118,7 @@ apiman:
                   configuration:
                     errorOnCorsFailure: true
                     allowOrigin:
-                      - 'http://192.168.99.100:3000'
+                      - 'http://192.168.99.100'
                     allowCredentials: false
                     exposeHeaders: []
                     allowHeaders:

--- a/docker/configr/requirements.txt
+++ b/docker/configr/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML==3.11
+requests==2.10.0

--- a/docker/echo-api/Dockerfile
+++ b/docker/echo-api/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.5-onbuild
+
+MAINTAINER Hans Keeler <hkeeler@gmail.com>
+
+EXPOSE 5000
+
+CMD ["gunicorn", "-c", "conf/gunicorn.py", "-b", "0.0.0.0:5000", "app:app"]

--- a/docker/echo-api/app.py
+++ b/docker/echo-api/app.py
@@ -1,0 +1,65 @@
+from flask import Flask, jsonify, request
+from werkzeug.exceptions import BadRequest 
+
+app = Flask(__name__)
+
+def build_response(request):
+    resp = {
+        "path": request.path,
+        "url": request.url,
+        "method": request.method,
+        "cookies": {c[0]: c[1] for c in request.cookies},
+        "headers": {h[0]: h[1] for h in request.headers},
+        "values": request.values, #{v[0]: v[1] for v in request.values}
+    }
+
+    raw_data = request.data
+    if raw_data:
+        resp['body'] = raw_data
+
+    try:
+        resp['body'] = request.get_json(force=True)
+    except BadRequest:
+        pass
+
+    return resp
+
+
+methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS', 'HEAD']
+
+@app.route('/', defaults={'path': ''}, methods=methods)
+@app.route('/<path:path>', methods=methods)
+def echo(path):
+
+    resp = build_response(request)
+
+    return jsonify(resp)
+
+
+def gen_error_json(message, code):
+    """
+    Builds standard JSON error message
+    """
+    resp = build_response(request)
+    resp['message'] = message
+    resp['statusCode'] = code
+
+    return jsonify(resp), code
+
+# Register all Flask error handlers
+@app.errorhandler(404)
+def not_found_error(error):
+    return gen_error_json('Resource not found', 404)
+
+@app.errorhandler(403)
+def forbidden_error(error):
+    print("Yep, you're in the Forbidden error hander!")
+    return gen_error_json(error.description, 403)
+
+@app.errorhandler(Exception)
+def default_error(error):
+    app.logger.exception('Internal server error')
+    return gen_error_json('Internal server error', 500)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', debug=True)

--- a/docker/echo-api/conf/gunicorn.py
+++ b/docker/echo-api/conf/gunicorn.py
@@ -1,0 +1,16 @@
+import multiprocessing
+
+# Number of workers based on Gunicorn docs:
+#   http://gunicorn-docs.readthedocs.org/en/latest/design.html#how-many-workers
+workers = multiprocessing.cpu_count() * 2 + 1
+
+# Logging
+loglevel = "info"
+# "-" = stderr
+accesslog = "-"
+errorlog = "-"
+
+# Accept X-Forwarded-For from reverse proxy:
+#   http://gunicorn-docs.readthedocs.org/en/latest/settings.html#forwarded-allow-ips
+#   http://gunicorn-docs.readthedocs.org/en/latest/deploy.html
+forwarded_allow_ips = "*"

--- a/docker/echo-api/requirements.txt
+++ b/docker/echo-api/requirements.txt
@@ -1,0 +1,4 @@
+cryptography==1.3.1
+flask==0.10.1
+gunicorn==19.4.5
+pyjwt==1.4.0


### PR DESCRIPTION
This is a work-in-progress.  Please give this a whirl, and see if the stack launches as expected.  More docs and rough-edge-smoothing coming soon...

This initial setup includes:

* A local Docker Compose setup.  This is temporary, and will be merged in with `hmda-platform`'s Compose setup once this is working smoothly.
    * `docker-compose up` is all you need to launch
    * `docker-compose rm -vfa configr apiman && docker-compose build --no-cache configr apiman && docker-compose up` may be necessary if you want to rebuild a an existing stack.
* Keycloak
    * Browse to: https://192.168.99.100:9443/auth/
    * Login with defaults: `admin:admin123!`
* APIMan
    * Browse to: https://192.168.99.100:9443/apimanui/
    * Login with same credentials as above
* Echo API for testing:
    * No Authentication: https://192.168.99.100:9443/apiman-gateway/hmda/echo/noauth
    * With Authentication: https://192.168.99.100:9443/apiman-gateway/hmda/echo/v1
* HMDA Platform API:
    * No Authentication: https://192.168.99.100:9443/apiman-gateway/hmda/hmda-platform/noauth
    * With Authentication: https://192.168.99.100:9443/apiman-gateway/hmda/hmda-platform/v1
    
