### PR TITLE
Set redirect uris at runtime from envvar

### DIFF
--- a/keycloak/docker-entrypoint.sh
+++ b/keycloak/docker-entrypoint.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+if [ -z ${REDIRECT_URIS+x} ]; then
+  echo 'REDIRECT_URIS environment variable not set' >&2
+  exit 1
+else
+  sed -i "s@{{REDIRECT_URIS}}@$REDIRECT_URIS@g" import/hmda-realm.json
+  echo "Keycloak redirect uris set to $REDIRECT_URIS"
+fi
+
 if [ $KEYCLOAK_USER ] && [ $KEYCLOAK_PASSWORD ]; then
     keycloak/bin/add-user-keycloak.sh --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD
 fi
@@ -9,10 +17,9 @@ if [ $INSTITUTION_SEARCH_URI ]; then
     echo 'Keycloak "login" theme.properties updated:'
     cat keycloak/themes/hmda/login/theme.properties
 else
-    echo 'INSTITUTION_SEARCH_URI environmental variable not set' >&2
+    echo 'INSTITUTION_SEARCH_URI environment variable not set' >&2
     exit 1
 fi
-
 
 exec /opt/jboss/keycloak/bin/standalone.sh $@
 exit $?

--- a/keycloak/import/hmda-realm.json
+++ b/keycloak/import/hmda-realm.json
@@ -539,7 +539,7 @@
     "surrogateAuthRequired" : false,
     "enabled" : true,
     "clientAuthenticatorType" : "client-secret",
-    "redirectUris" : [ "http://192.168.99.100/oidc-callback", "http://192.168.99.100/silent_renew.html" ],
+    "redirectUris" : {{REDIRECT_URIS}},
     "webOrigins" : [ "*" ],
     "notBefore" : 0,
     "bearerOnly" : false,


### PR DESCRIPTION
Builds on the current runtime setup in `docker-entrypoint` to also set the redirect uris used by keycloak