### PR TITLE
Add support email address to login theme's error message

### DIFF
--- a/keycloak/docker-entrypoint.sh
+++ b/keycloak/docker-entrypoint.sh
@@ -5,21 +5,33 @@ if [ -z ${REDIRECT_URIS+x} ]; then
   exit 1
 else
   sed -i "s@{{REDIRECT_URIS}}@$REDIRECT_URIS@g" import/hmda-realm.json
-  echo "Keycloak redirect uris set to $REDIRECT_URIS"
+  echo "Keycloak redirect URIs set to $REDIRECT_URIS"
 fi
 
-if [ $KEYCLOAK_USER ] && [ $KEYCLOAK_PASSWORD ]; then
+if [ ! -z ${KEYCLOAK_USER+x} ] && [ ! -z ${KEYCLOAK_PASSWORD+x} ]; then
     keycloak/bin/add-user-keycloak.sh --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD
 fi
 
-if [ $INSTITUTION_SEARCH_URI ]; then
-    sed -i "s@{{INSTITUTION_SEARCH_URI}}@$INSTITUTION_SEARCH_URI@g" keycloak/themes/hmda/login/theme.properties
-    echo 'Keycloak "login" theme.properties updated:'
-    cat keycloak/themes/hmda/login/theme.properties
-else
+if [ -z ${INSTITUTION_SEARCH_URI+x} ]; then
     echo 'INSTITUTION_SEARCH_URI environment variable not set' >&2
     exit 1
+else
+    echo "INSTITUTION_SEARCH_URI=$INSTITUTION_SUPPORT_URI"
+    sed -i "s@{{INSTITUTION_SEARCH_URI}}@$INSTITUTION_SEARCH_URI@g" keycloak/themes/hmda/login/theme.properties
+    echo "Set institutionSearchUri=$INSTITUTION_SEARCH_URI"
 fi
+
+if [ -z ${SUPPORT_EMAIL+x} ]; then
+    echo 'SUPPORT_EMAIL environment variable not set' >&2
+    exit 1
+else
+    echo "SUPPORT_EMAIL=$SUPPORT_EMAIL"
+    sed -i "s/{{SUPPORT_EMAIL}}/$SUPPORT_EMAIL/g" keycloak/themes/hmda/login/theme.properties
+    echo "Set supportEmail=$SUPPORT_EMAIL"
+fi
+
+echo 'Keycloak "login" theme.properties updated:'
+cat keycloak/themes/hmda/login/theme.properties
 
 exec /opt/jboss/keycloak/bin/standalone.sh $@
 exit $?

--- a/keycloak/themes/hmda/login/messages/messages_en.properties
+++ b/keycloak/themes/hmda/login/messages/messages_en.properties
@@ -1,0 +1,5 @@
+missingInstitutionMessage=Please specify Institution(s).
+invalidInstitutionMessage=Institution <em>{0}</em> is not associated with <em>{1}</em> email domain.
+unknownInstitutionMessage=Institution <em>{0}</em> is not found.
+unknownEmailDomainMessage=Email domain <em>{0}</em> not in CFPB whitelist.
+institutionErrorMessage=Error occurred while validating institution(s) against <em>{0}</em> domain.

--- a/keycloak/themes/hmda/login/messages/messages_en.properties
+++ b/keycloak/themes/hmda/login/messages/messages_en.properties
@@ -1,5 +1,5 @@
-missingInstitutionMessage=Please specify Institution(s).
-invalidInstitutionMessage=Institution <em>{0}</em> is not associated with <em>{1}</em> email domain.
-unknownInstitutionMessage=Institution <em>{0}</em> is not found.
-unknownEmailDomainMessage=Email domain <em>{0}</em> not in CFPB whitelist.
-institutionErrorMessage=Error occurred while validating institution(s) against <em>{0}</em> domain.
+missingInstitutionMessage=Please specify the Institution(s) for which you will be filing HMDA data.
+invalidInstitutionMessage=Institution <strong>{0}</strong> is not associated with <strong>{1}</strong> email domain.
+unknownInstitutionMessage=No Institution found with an identifier of <strong>{0}</strong>.
+unknownEmailDomainMessage=The email domain <strong>{0}</strong> is not in the known list of HMDA filer domains.
+institutionErrorMessage=An error occurred while validating the institution(s) against the <strong>{0}</strong> email domain.

--- a/keycloak/themes/hmda/login/template.ftl
+++ b/keycloak/themes/hmda/login/template.ftl
@@ -60,7 +60,7 @@
               <div class="usa-alert-body">
                 <h3 class="usa-alert-heading">${message.type} Status</h3>
                 <p class="usa-alert-text">${message.summary}</p>
-                <p>For help account-related issues, please contact <a href="mailto:${properties.supportEmail!}">${properties.supportEmail}</a></em>.</p>
+                <p>For help account-related issues, please contact <strong>${properties.supportEmail!}</strong>.</p>
               </div>
             </div>
           </div>

--- a/keycloak/themes/hmda/login/template.ftl
+++ b/keycloak/themes/hmda/login/template.ftl
@@ -60,7 +60,9 @@
               <div class="usa-alert-body">
                 <h3 class="usa-alert-heading">${message.type} Status</h3>
                 <p class="usa-alert-text">${message.summary}</p>
-                <p>For help account-related issues, please contact <strong>${properties.supportEmail!}</strong>.</p>
+                <p>For help account-related issues, please contact
+                    <strong><a href="mailto:${properties.supportEmailTo!}?subject=${properties.supportEmailSubject?url('UTF-8')}">${properties.supportEmailTo}</a></strong>.
+                </p>
               </div>
             </div>
           </div>

--- a/keycloak/themes/hmda/login/template.ftl
+++ b/keycloak/themes/hmda/login/template.ftl
@@ -60,6 +60,7 @@
               <div class="usa-alert-body">
                 <h3 class="usa-alert-heading">${message.type} Status</h3>
                 <p class="usa-alert-text">${message.summary}</p>
+                <p>For help account-related issues, please contact <a href="mailto:${properties.supportEmail!}">${properties.supportEmail}</a></em>.</p>
               </div>
             </div>
           </div>

--- a/keycloak/themes/hmda/login/theme.properties
+++ b/keycloak/themes/hmda/login/theme.properties
@@ -2,5 +2,5 @@ parent=keycloak
 scripts=lib/jquery/jquery-1.10.2.js lib/select2-3.4.1/select2.min.js
 styles=css/uswds.min.css lib/select2-3.4.1/select2.css css/select2-custom.css
 
-institutionSearchUri=https://192.168.99.100:9443
-supportEmail=support@localhost.localdomain
+institutionSearchUri={{INSTITUTION_SEARCH_URI}}
+supportEmail={{SUPPORT_EMAIL}}

--- a/keycloak/themes/hmda/login/theme.properties
+++ b/keycloak/themes/hmda/login/theme.properties
@@ -2,4 +2,5 @@ parent=keycloak
 scripts=lib/jquery/jquery-1.10.2.js lib/select2-3.4.1/select2.min.js
 styles=css/uswds.min.css lib/select2-3.4.1/select2.css css/select2-custom.css
 
-institutionSearchUri={{INSTITUTION_SEARCH_URI}}
+institutionSearchUri=https://192.168.99.100:9443
+supportEmail=support@localhost.localdomain

--- a/keycloak/themes/hmda/login/theme.properties
+++ b/keycloak/themes/hmda/login/theme.properties
@@ -3,4 +3,5 @@ scripts=lib/jquery/jquery-1.10.2.js lib/select2-3.4.1/select2.min.js
 styles=css/uswds.min.css lib/select2-3.4.1/select2.css css/select2-custom.css
 
 institutionSearchUri={{INSTITUTION_SEARCH_URI}}
-supportEmail={{SUPPORT_EMAIL}}
+supportEmailTo={{SUPPORT_EMAIL}}
+supportEmailSubject=HMDA Account Issue


### PR DESCRIPTION
This PR adds an extra line to the error section of the `login` theme.  I tried to make the message generic enough to apply to any type of account-related error (login, registration, password reset, etc.).  The value is set via a new `SUPPORT_EMAIL` envvar set at Keycloak container startup.

This PR also moves all custom error message from the Java class to a `messages_en.properties` file.  This follows the pattern Keycloak follows for its own error messages, and can be use to override existing Keycloak messages.

Closes #33 