### PR TITLE
Upgrade to Keycloak 2.5.0

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -6,7 +6,7 @@ ENV MAVEN_FILE=$MAVEN_DIST-bin.tar.gz
 ENV PATH=$PATH:/tmp/$MAVEN_DIST/bin
 ENV KC_SPI_SRC=providers
 ENV KC_SPI_DEST=/usr/src/keycloak
-ENV KC_VER=2.5.0.Final
+ENV KC_VER=2.4.0.Final
 
 # Install Maven (YUM version is too old)
 RUN curl -s -o /tmp/${MAVEN_FILE} http://www-us.apache.org/dist/maven/maven-3/${MAVEN_VER}/binaries/${MAVEN_FILE} && \

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -6,7 +6,9 @@ ENV MAVEN_FILE=$MAVEN_DIST-bin.tar.gz
 ENV PATH=$PATH:/tmp/$MAVEN_DIST/bin
 ENV KC_SPI_SRC=providers
 ENV KC_SPI_DEST=/usr/src/keycloak
-ENV KC_VER=2.4.0.Final
+
+# Keycloak never published 2.5.0 libs, but 2.4.0.Final libs do work on 2.5.0.Final server.
+ENV KC_LIB_VER=2.4.0.Final
 
 # Install Maven (YUM version is too old)
 RUN curl -s -o /tmp/${MAVEN_FILE} http://www-us.apache.org/dist/maven/maven-3/${MAVEN_VER}/binaries/${MAVEN_FILE} && \
@@ -51,7 +53,7 @@ USER jboss
 RUN echo 'Keycloak SPI build starting...' && \
     cd ${KC_SPI_DEST}/${KC_SPI_SRC}/authenticator/hmda && \
     mvn --quiet clean install && \
-    cp target/keycloak-authenticator-hmda-${KC_VER}.jar /opt/jboss/keycloak/providers && \
+    cp target/keycloak-authenticator-hmda-${KC_LIB_VER}.jar /opt/jboss/keycloak/providers && \
     echo 'Keycloak SPIs build successful!'
 
 USER root

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,4 +1,4 @@
-FROM jboss/keycloak-postgres:2.4.0.Final
+FROM jboss/keycloak-postgres:2.5.0.Final
 
 ENV MAVEN_VER=3.3.9
 ENV MAVEN_DIST=apache-maven-$MAVEN_VER
@@ -6,6 +6,7 @@ ENV MAVEN_FILE=$MAVEN_DIST-bin.tar.gz
 ENV PATH=$PATH:/tmp/$MAVEN_DIST/bin
 ENV KC_SPI_SRC=providers
 ENV KC_SPI_DEST=/usr/src/keycloak
+ENV KC_VER=2.5.0.Final
 
 # Install Maven (YUM version is too old)
 RUN curl -s -o /tmp/${MAVEN_FILE} http://www-us.apache.org/dist/maven/maven-3/${MAVEN_VER}/binaries/${MAVEN_FILE} && \
@@ -50,7 +51,7 @@ USER jboss
 RUN echo 'Keycloak SPI build starting...' && \
     cd ${KC_SPI_DEST}/${KC_SPI_SRC}/authenticator/hmda && \
     mvn --quiet clean install && \
-    cp target/keycloak-authenticator-hmda-2.4.0.Final.jar /opt/jboss/keycloak/providers && \
+    cp target/keycloak-authenticator-hmda-${KC_VER}.jar /opt/jboss/keycloak/providers && \
     echo 'Keycloak SPIs build successful!'
 
 USER root

--- a/keycloak/providers/authenticator/hmda/pom.xml
+++ b/keycloak/providers/authenticator/hmda/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>2.4.0.Final</version>
+        <version>2.5.0.Final</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/keycloak/providers/authenticator/hmda/pom.xml
+++ b/keycloak/providers/authenticator/hmda/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>2.5.0.Final</version>
+        <version>2.4.0.Final</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/keycloak/standalone.xml
+++ b/keycloak/standalone.xml
@@ -255,7 +255,9 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:infinispan:4.0">
             <cache-container name="keycloak" jndi-name="infinispan/Keycloak">
-                <local-cache name="realms"/>
+                <local-cache name="realms">
+                    <eviction max-entries="10000" strategy="LRU"/>
+                </local-cache>
                 <local-cache name="users">
                     <eviction max-entries="10000" strategy="LRU"/>
                 </local-cache>

--- a/keycloak/themes/hmda/login/login-reset-password.ftl
+++ b/keycloak/themes/hmda/login/login-reset-password.ftl
@@ -12,7 +12,7 @@
 
             <p>${msg("emailInstruction")}</p>
 
-            <label for="username"><#if !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
+            <label for="username"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
             <input type="text" id="username" name="username" autofocus/>
 
             <input name="reset" id="kc-reset" type="submit" value="${msg("doSubmit")}"/>

--- a/keycloak/themes/hmda/login/login.ftl
+++ b/keycloak/themes/hmda/login/login.ftl
@@ -11,11 +11,11 @@
                     <legend class="usa-drop_text">Sign in</legend>
                     <span>or <a href="${url.registrationUrl}">create an account</a></span>
 
-                    <label for="username"><#if !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
+                    <label for="username"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
                     <#if usernameEditDisabled??>
                         <input id="username" name="username" type="text" autocapitalize="off" autocorrect="off" value="${(login.username!'')?html}" disabled>
                     <#else>
-                        <input id="username" name="username" value="${(login.username!'')?html}" type="text" autofocus />
+                        <input id="username" name="username" value="${(login.username!'')?html}" type="text" autofocus autocomplete="off" />
                     </#if>
 
                     <label for="password">${msg("password")}</label>

--- a/keycloak/themes/hmda/login/theme.properties
+++ b/keycloak/themes/hmda/login/theme.properties
@@ -2,6 +2,7 @@ parent=keycloak
 scripts=lib/jquery/jquery-1.10.2.js lib/select2-3.4.1/select2.min.js
 styles=css/uswds.min.css lib/select2-3.4.1/select2.css css/select2-custom.css css/hmda.css
 
+# WARNING: These placeholders are overridden on container startup.  Do not commit overridden values.
 institutionSearchUri={{INSTITUTION_SEARCH_URI}}
 supportEmailTo={{SUPPORT_EMAIL}}
 supportEmailSubject=HMDA Account Issue


### PR DESCRIPTION
Closes #47

I've upgrade the Docker image to `2.5.0.Final`.  There were a couple templates that had to be tweaked, and a cache-related change to `standalone.xml`, but that seems to be it!  I've done some local testing, and all appears to be working.

The one wrinkle is that they haven't pushed up a `2.5.0.Final` version of the [Adapters SPI](https://mvnrepository.com/artifact/org.keycloak/keycloak-adapter-spi) Java libs...yet?

I am currently building with `2.4.0.Final`, and again, it _seems_ fine, but I'd like to do a bit more testing before giving the green light to merge.