### PR TITLE
Refactor Keycloak institution search by email domain

### DIFF
--- a/institution-search/data/institutions.yaml
+++ b/institution-search/data/institutions.yaml
@@ -1,21 +1,47 @@
 institutions:
 
   - id: '0'
-    name: Bank 0
-    domain: [bank0.com]
-    regulator: FDIC
+    name: 'Bank 0'
+    domains:
+      - 'bank0.com'
+    externalIds:
+      - name: 'RSSD ID'
+        value: '1234567'
+      - name: 'EIN'
+        value: '12-3456789'
+      - name: 'FDIC Cert No'
+        value: '12345'
    
   - id: '1'
-    name: Bank 1
-    domain: [bank1.com]
-    regulator: CFPB
-  
+    name: 'Bank 1'
+    domains:
+      - 'bank1.com'
+      - 'bankone.com'
+    externalIds:
+      - name: 'RSSD ID'
+        value: '1111111'
+      - name: 'EIN'
+        value: '11-1111111'
+ 
   - id: '2'
-    name: Bank 2
-    domain: [bank2.com]
-    regulator: OCC
-  
+    name: 'Bank 2'
+    domains: 
+      - 'bank2.com'
+    externalIds:
+      - name: 'RSSD ID'
+        value: '2222222'
+      - name: 'EIN'
+        value: '22-2222222'
+
   - id: '3'
-    name: Bank 3 
-    domain: [bank3.com]
-    regulator: HUD
+    name: 'Bank 2 Too'
+    domains: 
+      - 'bank2.com'
+    externalIds:
+      - name: 'RSSD ID'
+        value: '3333333'
+      - name: 'EIN'
+        value: '33-3333333'
+      - name: 'NCUA Charter'
+        value: '333333'
+

--- a/keycloak/providers/authenticator/hmda/src/main/java/gov/cfpb/keycloak/authenticator/hmda/ExternalId.java
+++ b/keycloak/providers/authenticator/hmda/src/main/java/gov/cfpb/keycloak/authenticator/hmda/ExternalId.java
@@ -1,0 +1,36 @@
+package gov.cfpb.keycloak.authenticator.hmda;
+
+import java.util.Objects;
+
+/**
+ * Created by keelerh on 1/25/17.
+ */
+public class ExternalId {
+
+    private String name;
+    private String value;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return "ExternalId{" +
+                "name='" + name + '\'' +
+                ", value='" + value + '\'' +
+                '}';
+    }
+}

--- a/keycloak/providers/authenticator/hmda/src/main/java/gov/cfpb/keycloak/authenticator/hmda/ExternalIdType.java
+++ b/keycloak/providers/authenticator/hmda/src/main/java/gov/cfpb/keycloak/authenticator/hmda/ExternalIdType.java
@@ -1,8 +1,0 @@
-package gov.cfpb.keycloak.authenticator.hmda;
-
-// This is not yet used, but will be once we sync with hmda-platform
-public enum ExternalIdType {
-
-    FDIC_CHARTER, RSSD_ID;
-
-}

--- a/keycloak/providers/authenticator/hmda/src/main/java/gov/cfpb/keycloak/authenticator/hmda/HmdaValidInstitutionsFormAction.java
+++ b/keycloak/providers/authenticator/hmda/src/main/java/gov/cfpb/keycloak/authenticator/hmda/HmdaValidInstitutionsFormAction.java
@@ -2,10 +2,7 @@ package gov.cfpb.keycloak.authenticator.hmda;
 
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
-import org.keycloak.authentication.FormAction;
-import org.keycloak.authentication.FormActionFactory;
-import org.keycloak.authentication.FormContext;
-import org.keycloak.authentication.ValidationContext;
+import org.keycloak.authentication.*;
 import org.keycloak.authentication.forms.RegistrationPage;
 import org.keycloak.events.Errors;
 import org.keycloak.forms.login.LoginFormsProvider;
@@ -15,20 +12,8 @@ import org.keycloak.provider.ConfiguredProvider;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.services.validation.Validation;
 
-import javax.net.ssl.*;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 
 public class HmdaValidInstitutionsFormAction implements FormAction, FormActionFactory, ConfiguredProvider {
@@ -41,68 +26,9 @@ public class HmdaValidInstitutionsFormAction implements FormAction, FormActionFa
     public static final String UNKNOWN_EMAIL_DOMAIN_MESSAGE = "unknownEmailDomainMessage";
     public static final String INSTITUTION_ERROR_MESSAGE = "institutionErrorMessage";
 
-    private static final WebTarget apiClient;
+    private InstitutionService institutionService;
 
     private static final Logger logger = Logger.getLogger(HmdaValidInstitutionsFormAction.class);
-
-    static {
-        //FIXME: Should probably switch envvar handling to using Keycloak built-in Config features
-        String validateSsl = System.getenv("INSTITUTION_SEARCH_VALIDATE_SSL");
-        String apiUri = System.getenv("INSTITUTION_SEARCH_URI");
-
-        ClientBuilder apiClientBuilder = ClientBuilder.newBuilder();
-
-        // Special handling for dealing with untrusted HTTPS calls
-        if(validateSsl.trim().toUpperCase().equals("OFF")) {
-            try {
-                TrustManager[] tm = new TrustManager[] {
-                    new X509TrustManager() {
-                        @Override public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {}
-                        @Override public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {}
-                        @Override public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
-                    }};
-
-                HostnameVerifier hv = new HostnameVerifier() {
-                    @Override public boolean verify(String s, SSLSession sslSession) { return true; }
-                };
-
-                SSLContext sslCtx = SSLContext.getInstance("TLS");
-                sslCtx.init(null, tm, new SecureRandom());
-
-                apiClientBuilder.sslContext(sslCtx).hostnameVerifier(hv).build();
-            } catch (NoSuchAlgorithmException|KeyManagementException ex) {
-                throw new RuntimeException(ex);
-            }
-
-            logger.warn("SSL validation is disabled.  This should not be enabled in a production environemnt.");
-        }
-
-        apiClient = apiClientBuilder.build()
-                .register(InstitutionSearchResultsReader.class)
-                .target(apiUri)
-                .path("institutions");
-    }
-
-    private Set<Institution> findInstitutionsByDomain(String domain) {
-        WebTarget target = apiClient.queryParam("domain", domain);
-        InstitutionSearchResults results = target.request(MediaType.APPLICATION_JSON_TYPE).get(InstitutionSearchResults.class);
-
-        return new HashSet<>(results.getResults());
-    }
-
-    private Institution getInstitution(String id) {
-        WebTarget target = apiClient.queryParam("id", id);
-        InstitutionSearchResults results = target.request(MediaType.APPLICATION_JSON_TYPE).get(InstitutionSearchResults.class);
-
-        // FIXME: This should use a /institutions/{id} endpoint
-        List<Institution> insts = results.getResults();
-
-        if (insts.isEmpty())
-            // FIXME: Throw exception on inst_not_found?
-            return null;
-        else
-            return insts.get(0);
-    }
 
     @Override
     public void buildPage(FormContext context, LoginFormsProvider form) {
@@ -130,31 +56,38 @@ public class HmdaValidInstitutionsFormAction implements FormAction, FormActionFa
         }
 
         try {
-            String[] instIds = instFieldVal.split(",");
+            Set<String> userInstIds = new HashSet<>(Arrays.asList(instFieldVal.split(",")));
             String email = formData.getFirst(RegistrationPage.FIELD_EMAIL);
             domain = email.split("@")[1];
 
             logger.info("Email Domain: " + domain);
 
-
-            Set<Institution> domainInsts = findInstitutionsByDomain(domain);
+            Set<Institution> domainInsts = institutionService.findInstitutionsByDomain(domain);
 
             if (domainInsts.isEmpty()) {
                 errors.add(new FormMessage(RegistrationPage.FIELD_EMAIL, UNKNOWN_EMAIL_DOMAIN_MESSAGE, domain));
                 context.validationError(formData, errors);
                 context.error(Errors.INVALID_REGISTRATION);
+
                 return;
             }
 
-            for (String instId : instIds) {
-                Institution inst = getInstitution(instId);
+            // Get a set of institutionId(s) for a given domain
+            Set<String> domainInstIds = new HashSet<>(domainInsts.size());
+            for (Institution domainInstId : domainInsts) {
+                domainInstIds.add(domainInstId.getId());
+            }
 
-                if (inst == null) {
-                    errors.add(new FormMessage(FIELD_INSTITUTIONS, UNKNOWN_INSTITUTION_MESSAGE, instId));
-                }
+            // Add error for every institution submitted not associated with domain
+            if (!domainInsts.containsAll(userInstIds)) {
 
-                if (!domainInsts.contains(inst)) {
-                    errors.add(new FormMessage(FIELD_INSTITUTIONS, INVALID_INSTITUTION_MESSAGE, inst.getName(), domain));
+                // Remove all matched institutions
+                userInstIds.removeAll(domainInstIds);
+                
+                for (String userInstId : userInstIds) {
+                    if (!domainInsts.contains(userInstId)) {
+                        errors.add(new FormMessage(FIELD_INSTITUTIONS, INVALID_INSTITUTION_MESSAGE, userInstId, domain));
+                    }
                 }
             }
 
@@ -197,7 +130,12 @@ public class HmdaValidInstitutionsFormAction implements FormAction, FormActionFa
 
     @Override
     public void init(Config.Scope scope) {
+        String uri = scope.get("institutionSearchUri");
+        Boolean validateSsl = scope.getBoolean("institutionSearchValidateSsl", true);
 
+        logger.info("Initializing institution search: uri="+uri+", validateSsl="+validateSsl);
+
+        institutionService = new InstitutionSearchHmdaApiImpl(uri, validateSsl);
     }
 
     @Override
@@ -253,7 +191,7 @@ public class HmdaValidInstitutionsFormAction implements FormAction, FormActionFa
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        // FIXME: Add Institution API endpoint config
+        //TODO: Fill in uri and validateSsl here
         return null;
     }
 

--- a/keycloak/providers/authenticator/hmda/src/main/java/gov/cfpb/keycloak/authenticator/hmda/Institution.java
+++ b/keycloak/providers/authenticator/hmda/src/main/java/gov/cfpb/keycloak/authenticator/hmda/Institution.java
@@ -1,14 +1,14 @@
 package gov.cfpb.keycloak.authenticator.hmda;
 
-import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 public class Institution {
 
     private String id;
     private String name;
-    private String regulator;
-    private List<String> domain;
+    private Set<String> domains;
+    private Set<ExternalId> externalIds;
 
     public Institution() {
     }
@@ -29,36 +29,20 @@ public class Institution {
         this.name = name;
     }
 
-    public String getRegulator() {
-        return regulator;
+    public Set<String> getDomains() {
+        return domains;
     }
 
-    public void setRegulator(String regulator) {
-        this.regulator = regulator;
+    public void setDomains(Set<String> domains) {
+        this.domains = domains;
     }
 
-    public List<String> getDomain() {
-        return domain;
+    public Set<ExternalId> getExternalIds() {
+        return externalIds;
     }
 
-    public void setDomain(List<String> domain) {
-        this.domain = domain;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Institution that = (Institution) o;
-        return Objects.equals(id, that.id) &&
-                Objects.equals(name, that.name) &&
-                Objects.equals(regulator, that.regulator) &&
-                Objects.equals(domain, that.domain);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, name, regulator, domain);
+    public void setExternalIds(Set<ExternalId> externalIds) {
+        this.externalIds = externalIds;
     }
 
     @Override
@@ -66,8 +50,8 @@ public class Institution {
         return "Institution{" +
                 "id='" + id + '\'' +
                 ", name='" + name + '\'' +
-                ", regulator='" + regulator + '\'' +
-                ", domain=" + domain +
+                ", domains=" + domains +
+                ", externalIds=" + externalIds +
                 '}';
     }
 }

--- a/keycloak/providers/authenticator/hmda/src/main/java/gov/cfpb/keycloak/authenticator/hmda/InstitutionSearchHmdaApiImpl.java
+++ b/keycloak/providers/authenticator/hmda/src/main/java/gov/cfpb/keycloak/authenticator/hmda/InstitutionSearchHmdaApiImpl.java
@@ -1,0 +1,72 @@
+package gov.cfpb.keycloak.authenticator.hmda;
+
+import org.jboss.logging.Logger;
+
+import javax.net.ssl.*;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.HashSet;
+import java.util.Set;
+
+
+public class InstitutionSearchHmdaApiImpl implements InstitutionService {
+
+    private static final Logger logger = Logger.getLogger(InstitutionSearchHmdaApiImpl.class);
+
+    private WebTarget apiClient;
+
+    public InstitutionSearchHmdaApiImpl(String apiUri, Boolean validateSsl) {
+        this.apiClient = buildClient(apiUri, validateSsl);
+    }
+
+    private WebTarget buildClient(String apiUri, Boolean validateSsl) {
+        ClientBuilder apiClientBuilder = ClientBuilder.newBuilder();
+
+        // Special handling for dealing with untrusted HTTPS calls
+        if(!validateSsl) {
+            try {
+                TrustManager[] tm = new TrustManager[] {
+                        new X509TrustManager() {
+                            @Override public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {}
+                            @Override public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {}
+                            @Override public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
+                        }};
+
+                HostnameVerifier hv = new HostnameVerifier() {
+                    @Override public boolean verify(String s, SSLSession sslSession) { return true; }
+                };
+
+                SSLContext sslCtx = SSLContext.getInstance("TLS");
+                sslCtx.init(null, tm, new SecureRandom());
+
+                apiClientBuilder.sslContext(sslCtx).hostnameVerifier(hv).build();
+            } catch (NoSuchAlgorithmException |KeyManagementException ex) {
+                throw new RuntimeException(ex);
+            }
+
+            logger.warn("SSL validation is disabled.  This should not be enabled in a production environemnt.");
+        }
+
+        apiClient = apiClientBuilder.build()
+                .register(InstitutionSearchResultsReader.class)
+                .target(apiUri)
+                .path("institutions");
+
+        return apiClient;
+    }
+
+    @Override
+    public Set<Institution> findInstitutionsByDomain(String domain) {
+        WebTarget target = apiClient.queryParam("domain", domain);
+        InstitutionSearchResults results = target.request(MediaType.APPLICATION_JSON_TYPE).get(InstitutionSearchResults.class);
+
+        return new HashSet<>(results.getResults());
+    }
+
+}

--- a/keycloak/providers/authenticator/hmda/src/main/java/gov/cfpb/keycloak/authenticator/hmda/InstitutionService.java
+++ b/keycloak/providers/authenticator/hmda/src/main/java/gov/cfpb/keycloak/authenticator/hmda/InstitutionService.java
@@ -1,0 +1,12 @@
+package gov.cfpb.keycloak.authenticator.hmda;
+
+import java.util.Set;
+
+/**
+ * Created by keelerh on 1/26/17.
+ */
+public interface InstitutionService {
+
+    public Set<Institution> findInstitutionsByDomain(String domain);
+
+}

--- a/keycloak/standalone.xml
+++ b/keycloak/standalone.xml
@@ -513,6 +513,14 @@
                     </properties>
                 </provider>
             </spi>
+            <spi name="form-action">
+                <provider name="registration-institution-action" enabled="true">
+                    <properties>
+                        <property name="institutionSearchUri" value="${env.INSTITUTION_SEARCH_URI}"/>
+                        <property name="institutionSearchValidateSsl" value="${env.INSTITUTION_SEARCH_VALIDATE_SSL}"/>
+                    </properties>
+                </provider>
+            </spi>
         </subsystem>
     </profile>
     <interfaces>

--- a/keycloak/themes/hmda/login/register.ftl
+++ b/keycloak/themes/hmda/login/register.ftl
@@ -60,24 +60,22 @@ function getFormEmail() {
   return $("#email").val().trim().toLowerCase();
 }
 
-function isValidDomain(email, domain) {
-  return emailToDomain(email) === domain;
-}
+function genExternalIdsHtml(institution) {
+  var externalIds = institution.externalIds;
+  var externalIdsHtml = "";
+  externalIds.forEach(function(externalId){
+    var idName = externalId.name;
+    var idValue = externalId.value;
+    externalIdsHtml = externalIdsHtml + '    <p><strong>' + idName + '</strong> ' + idValue  + '</p>';
+  });
 
-function getStatusIcon(email, domain) {
-  var statusIcon = '';
-  if(isValidDomain(email, domain))
-    statusIcon =  '<i style="color:#20aa3f;" class="fa fa-check-circle" aria-hidden="true"></i>';
-  else
-    statusIcon =  '<i style="color:#ff9e1b;" class="fa fa-warning" aria-hidden="true"></i>';
-
-  return statusIcon;
+  return externalIdsHtml;
 }
 
 $(document).ready(function() {
   $("#user\\.attributes\\.institutions").select2({
     placeholder: "Start typing to select institution(s)",
-    minimumInputLength: 3,
+    //minimumInputLength: 3,
     multiple: true,
     allowClear: true,
     width: "450px",
@@ -85,12 +83,9 @@ $(document).ready(function() {
     ajax: {
       url: institutionSearchUri,
       data: function(term, page) {
-        // Search based on user input
-        return { search: term }
-
         // Search based on "email" form field
-        //var domain = emailToDomain($("#email").val());
-        //return { domain: domain }
+        var domain = emailToDomain($("#email").val());
+        return { domain: domain }
       },
       results: function(data, page) {
         return {
@@ -103,19 +98,16 @@ $(document).ready(function() {
       return markup;
     },
     formatSelection: function(institution) {
-      return  institution.name + ' (' + institution.id + ') ' + getStatusIcon(getFormEmail(), institution.domain[0]);
+      return  institution.name + ' (' + institution.id + ')';
     },
     formatResult: function(institution) {
       return '<div class="usa-grid-full">' +
              '  <h4>' + institution.name + '</h4>' +
              '  <div class="usa-width-one-half usa-text-small">' +
-             '    <p><strong>Regulator:</strong> ' + institution.regulator +
-             '    <p><strong>Domain:</strong> ' + institution.domain[0] +
+             '    <p><strong>Domain:</strong> ' + institution.domains +
              '  </div>' +
              '  <div class="usa-width-one-half usa-text-small">' +
-             '    <p><strong>Respondent ID:</strong> ' + institution.id + '</p>' +
-             '    <p><strong>EIN:</strong> 12-3456789</p>' +
-             '    <p><strong>FDIC Charter:</strong> 999999</p>' +
+             genExternalIdsHtml(institution) +
              '  </div>' +
              '</div>'
     }


### PR DESCRIPTION
This PR refactors Keycloak to search for institutions by email domain, rather than by name.  The institution search resource has been updated to reflect what was proposed on https://github.com/cfpb/hmda-platform/issues/778.

I have also made a few improvements:

1. The frontend now reads in the list of external IDs, rather than a hardcoded list.
1. Split the institution search client (`InstitutionService`) out from the form validation (`HmdaValidInstitutionsFormAction`).  This _should_ allow for easier unit testing, allowing a mock `InstitutionSearch` to be injected.
1. Standardizes institution search configs with the rest of the system configs in `standalone.xml`.

I was hoping to have some unit tests for `HmdaValidInstitutionsFormAction` included, but that will have to wait for a followup PR.