### PR TITLE
Disable cleanup steps in Keycloak Dockerfile

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -56,9 +56,4 @@ RUN echo 'Keycloak SPI build starting...' && \
     cp target/keycloak-authenticator-hmda-${KC_LIB_VER}.jar /opt/jboss/keycloak/providers && \
     echo 'Keycloak SPIs build successful!'
 
-USER root
-# Remove source and build tools
-RUN rm -rf ~/.m2 ${KC_SPI_DEST} /tmp/${MAVEN_FILE}
-USER jboss
-
 EXPOSE 8443


### PR DESCRIPTION
We're currently hitting up against what seems to be a kernel filesystem bug causing file removal to fail in certain scenarios.  To get around this, this PR simply stops deleting certain directories in the Keycloak image build.  This isn't a huge problem for this particular image since these steps are taken primarily to shrink the image size.

Once this has been fixed in all environments, these commands will be re-introduced.