### PR TITLE
Upgrade to Keycloak 3.0.0 and  mod_auth_openidc 2.2

### DIFF
--- a/auth-proxy/Dockerfile
+++ b/auth-proxy/Dockerfile
@@ -1,19 +1,18 @@
 FROM centos:7 
 
-ENV OIDC_VER 2.1.3 
+ENV OIDC_VER 2.2.0 
 ENV OIDC_PATCH 1
 ENV OIDC_PKG mod_auth_openidc-${OIDC_VER}-${OIDC_PATCH}.el7.centos.x86_64.rpm
 
 # Cisco's cjose lib is _usually_ on the same release as mod_auth_openidc
-ENV CJOSE_OIDC_VER 2.1.3
+ENV CJOSE_OIDC_VER 2.2.0
 ENV CJOSE_PKG cjose-0.4.1-1.el7.centos.x86_64.rpm
 
 ENV DL_SITE https://github.com/pingidentity/mod_auth_openidc/releases/download/
 
 ENV HTTPD_USER apache 
 
-RUN curl -sL -o /tmp/epel-release-7-9.noarch.rpm https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm && \
-    yum install -y /tmp/epel-release-7-9.noarch.rpm && \
+RUN yum install -y epel-release && \
     yum update -y && \
     yum install -y hiredis httpd jansson mod_ssl && \
     curl -sL -o /tmp/${CJOSE_PKG} ${DL_SITE}/v${CJOSE_OIDC_VER}/${CJOSE_PKG} && \

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,4 +1,4 @@
-FROM jboss/keycloak-postgres:2.5.0.Final
+FROM jboss/keycloak-postgres:3.0.0.Final
 
 ENV MAVEN_VER=3.3.9
 ENV MAVEN_DIST=apache-maven-$MAVEN_VER
@@ -6,9 +6,7 @@ ENV MAVEN_FILE=$MAVEN_DIST-bin.tar.gz
 ENV PATH=$PATH:/tmp/$MAVEN_DIST/bin
 ENV KC_SPI_SRC=providers
 ENV KC_SPI_DEST=/usr/src/keycloak
-
-# Keycloak never published 2.5.0 libs, but 2.4.0.Final libs do work on 2.5.0.Final server.
-ENV KC_LIB_VER=2.4.0.Final
+ENV KC_LIB_VER=3.0.0.Final
 
 # Install Maven (YUM version is too old)
 RUN curl -s -o /tmp/${MAVEN_FILE} http://www-us.apache.org/dist/maven/maven-3/${MAVEN_VER}/binaries/${MAVEN_FILE} && \

--- a/keycloak/image-diff.sh
+++ b/keycloak/image-diff.sh
@@ -18,9 +18,10 @@ DIFF_FILE="$DIFF_DEST_BASE/images.diff"
 function remove_container()
 {
     container=$1
-    echo "Removing container $container"
+    echo "Removing container $container..."
     if docker inspect $container ; then
         docker rm -vf $container
+        echo "Container $container removed."
     else
         echo "Container $container is not running"
     fi
@@ -37,7 +38,6 @@ function export_container()
 
     mkdir -p "$DIFF_DEST_BASE/$container"
 
-    echo "Removing container $container..."
     remove_container $container
 
     docker run --detach --name $container $DOCKER_RUN_OPTS $image

--- a/keycloak/providers/authenticator/hmda/pom.xml
+++ b/keycloak/providers/authenticator/hmda/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>2.4.0.Final</version>
+        <version>3.0.0.Final</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/keycloak/standalone.xml
+++ b/keycloak/standalone.xml
@@ -119,13 +119,9 @@
             <formatter name="COLOR-PATTERN">
                 <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
             </formatter>
-        <log:logger xmlns:log="urn:jboss:domain:logging:3.0" xmlns="" category="org.keycloak">
-            <log:level name="${env.KEYCLOAK_LOGLEVEL:INFO}"/>
-         </log:logger>
-      </subsystem>
-        <subsystem xmlns="urn:jboss:domain:deployment-scanner:2.0">
-            <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000"
-                             runtime-failure-causes-rollback="${jboss.deployment.scanner.rollback.on.failure:false}"/>
+            <log:logger xmlns:log="urn:jboss:domain:logging:3.0" xmlns="" category="org.keycloak">
+                <log:level name="${env.KEYCLOAK_LOGLEVEL:INFO}"/>
+             </log:logger>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:4.0">
@@ -172,6 +168,10 @@
                    </driver>
                 </drivers>
             </datasources>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:deployment-scanner:2.0">
+            <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000"
+                             runtime-failure-causes-rollback="${jboss.deployment.scanner.rollback.on.failure:false}"/>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:ee:4.0">
             <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
@@ -299,17 +299,13 @@
                     <file-store passivation="true" purge="false"/>
                 </local-cache>
                 <local-cache name="persistent">
+                    <locking isolation="REPEATABLE_READ"/>
                     <transaction mode="BATCH"/>
                     <file-store passivation="false" purge="false"/>
                 </local-cache>
             </cache-container>
             <cache-container name="hibernate" default-cache="local-query" module="org.hibernate.infinispan">
                 <local-cache name="entity">
-                    <transaction mode="NON_XA"/>
-                    <eviction strategy="LRU" max-entries="10000"/>
-                    <expiration max-idle="100000"/>
-                </local-cache>
-                <local-cache name="immutable-entity">
                     <transaction mode="NON_XA"/>
                     <eviction strategy="LRU" max-entries="10000"/>
                     <expiration max-idle="100000"/>
@@ -450,29 +446,16 @@
                 <dir>${jboss.home.dir}/themes</dir>
             </theme>
             <spi name="eventsStore">
-                <default-provider>jpa</default-provider>
                 <provider name="jpa" enabled="true">
                     <properties>
                         <property name="exclude-events" value="[&#34;REFRESH_TOKEN&#34;]"/>
                     </properties>
                 </provider>
             </spi>
-            <spi name="realm">
-                <default-provider>jpa</default-provider>
-            </spi>
-            <spi name="user">
-                <default-provider>jpa</default-provider>
-            </spi>
-            <spi name="userFederatedStorage">
-                <default-provider>jpa</default-provider>
-            </spi>
             <spi name="userCache">
                 <provider name="default" enabled="true"/>
             </spi>
             <spi name="userSessionPersister">
-                <default-provider>jpa</default-provider>
-            </spi>
-            <spi name="authorizationPersister">
                 <default-provider>jpa</default-provider>
             </spi>
             <spi name="timer">


### PR DESCRIPTION
Closes #69 
Closes #70 

This PR should get us up to date with the latest versions of Keycloak and mod_auth_openidc.  The build itself seems to be working fine.  ~~I'm still working on testing it with our full stack.~~  I've also done a few rounds of local testing, and it all seems to be working as expected.

If you're trying to figure out the changes made to `standalone.xml`, those are all changes that showed up when I did a diff between the Keycloak 2.5.0 and 3.0.0 images.  For details see https://github.com/cfpb/hmda-platform-auth/issues/69#issuecomment-297242076.