### PR TITLE
Password confirm error

### DIFF
--- a/keycloak/themes/hmda/login/register.ftl
+++ b/keycloak/themes/hmda/login/register.ftl
@@ -54,6 +54,7 @@
           <input type="password" id="password" name="password" />
 
           <label for="password-confirm">${msg("passwordConfirm")}</label>
+          <span class="usa-input-error-message" id="password-confirm-error-message" role="alert">Passwords do not match</span>
           <input type="password" id="password-confirm" name="password-confirm" />
         </#if>
 
@@ -170,5 +171,17 @@ $(document).ready(function() {
   }
 
   $('#institutions').on('click', '.institutionsCheck', addInstitutionsToInput);
+
+  // compare passwords
+  $('#password-confirm').on('keyup', function(e) {
+    // wait for the 12 character to check, we require a length of 12
+    if($('#password-confirm').val().length >= 12) {
+      if($('#password-confirm').val() !== $('#password').val()) {
+        $('#password-confirm-error-message').css('display', 'block');
+      } else {
+        $('#password-confirm-error-message').css('display', 'none');
+      }
+    }
+  })
 });
 </script>

--- a/keycloak/themes/hmda/login/register.ftl
+++ b/keycloak/themes/hmda/login/register.ftl
@@ -178,8 +178,10 @@ $(document).ready(function() {
     if($('#password-confirm').val().length >= 12) {
       if($('#password-confirm').val() !== $('#password').val()) {
         $('#password-confirm-error-message').css('display', 'block');
+        $('#password-confirm-error-message').prev().css('font-weight', 'bold');
       } else {
         $('#password-confirm-error-message').css('display', 'none');
+        $('#password-confirm-error-message').prev().css('font-weight', 'normal');
       }
     }
   })

--- a/keycloak/themes/hmda/login/resources/css/hmda.css
+++ b/keycloak/themes/hmda/login/resources/css/hmda.css
@@ -167,3 +167,7 @@ fieldset fieldset legend {
   padding-top: 3px;
   padding-bottom: 3px;
 }
+
+.usa-input-error-message {
+  display: none;
+}


### PR DESCRIPTION
Closes #113 

For now, this is following the [error message pattern](https://standards.usa.gov/components/form-controls/#text-input) from USWDS.

# Screenshot

![dontmatch](https://cloud.githubusercontent.com/assets/2932572/25952439/b46aad9a-362e-11e7-8695-3ae625374367.png)

