### PR TITLE
Upgrade Keycloak to 3.1.0.Final

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,4 +1,4 @@
-FROM jboss/keycloak-postgres:3.0.0.Final
+FROM jboss/keycloak-postgres:3.1.0.Final
 
 ENV MAVEN_VER=3.3.9
 ENV MAVEN_DIST=apache-maven-$MAVEN_VER
@@ -6,7 +6,7 @@ ENV MAVEN_FILE=$MAVEN_DIST-bin.tar.gz
 ENV PATH=$PATH:/tmp/$MAVEN_DIST/bin
 ENV KC_SPI_SRC=providers
 ENV KC_SPI_DEST=/usr/src/keycloak
-ENV KC_LIB_VER=3.0.0.Final
+ENV KC_LIB_VER=3.1.0.Final
 
 # Install Maven (YUM version is too old)
 RUN curl -s -o /tmp/${MAVEN_FILE} http://www-us.apache.org/dist/maven/maven-3/${MAVEN_VER}/binaries/${MAVEN_FILE} && \

--- a/keycloak/providers/authenticator/hmda/pom.xml
+++ b/keycloak/providers/authenticator/hmda/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>3.0.0.Final</version>
+        <version>3.1.0.Final</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Closes #110 

It's an easy upgrade this go around.  No changes to error messages, emails, or any frontend bits like we see in most upgrades.

I have done a full rebuild of all apps locally, and it looks like we're in good shape here.