### PR TITLE
Stale message improvement

### DIFF
--- a/keycloak/themes/hmda/login/error.ftl
+++ b/keycloak/themes/hmda/login/error.ftl
@@ -1,0 +1,13 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=false; section>
+    <#if section = "title">
+        ${msg("errorTitle")}
+    <#elseif section = "header">
+        ${msg("errorTitleHtml")}
+    <#elseif section = "form">
+        <div id="kc-error-message">
+            <p class="instruction">${message.summary}</p>
+            <p><a class="usa-button" id="backToApplication" href="${properties.homePageUri}/institutions">${msg("doLogIn")}</a></p>
+        </div>
+    </#if>
+</@layout.registrationLayout>

--- a/keycloak/themes/hmda/login/messages/messages_en.properties
+++ b/keycloak/themes/hmda/login/messages/messages_en.properties
@@ -26,4 +26,4 @@ invalidPasswordHistoryMessage=&#8226; Invalid password: must not be equal to any
 invalidPasswordGenericMessage=&#8226; Invalid password: new password doesn''t match password policies
 
 hmdaEnterEmailAddress=To register as a filer for more than one institution, you may select multiple institutions from the list of available institutions based on your email domain. If one or more institutions is not available in the list based on your email domain, contact {0} for assistance with registering for the additional institution(s).
-staleEmailVerificationLink=The link to verify your HMDA account registration appears to have been verified. Try logging in using the button below.
+staleEmailVerificationLink=The link to verify your HMDA account registration appears to have been visited. Try logging in using the button below.

--- a/keycloak/themes/hmda/login/messages/messages_en.properties
+++ b/keycloak/themes/hmda/login/messages/messages_en.properties
@@ -26,3 +26,4 @@ invalidPasswordHistoryMessage=&#8226; Invalid password: must not be equal to any
 invalidPasswordGenericMessage=&#8226; Invalid password: new password doesn''t match password policies
 
 hmdaEnterEmailAddress=To register as a filer for more than one institution, you may select multiple institutions from the list of available institutions based on your email domain. If one or more institutions is not available in the list based on your email domain, contact {0} for assistance with registering for the additional institution(s).
+staleEmailVerificationLink=The link to verify your HMDA account registration appears to have been verified. Try logging in using the button below.


### PR DESCRIPTION
Finishes up #102 by improving stale message and adding an action to login.

Had to include the `error` template.

## Screenshot

![stale-message](https://user-images.githubusercontent.com/2932572/29318242-404723ca-819d-11e7-8d4a-2bb55a30fc0d.png)
