### PR TITLE
Adds CentOS CR repo to auth-proxy to get latest patches

### DIFF
--- a/auth-proxy/Dockerfile
+++ b/auth-proxy/Dockerfile
@@ -13,6 +13,7 @@ ENV DL_SITE https://github.com/pingidentity/mod_auth_openidc/releases/download/
 ENV HTTPD_USER apache 
 
 RUN yum install -y epel-release && \
+    yum-config-manager --enable cr && \
     yum update -y && \
     yum install -y hiredis httpd jansson && \
     curl -sL -o /tmp/${CJOSE_PKG} ${DL_SITE}/v${CJOSE_OIDC_VER}/${CJOSE_PKG} && \


### PR DESCRIPTION
In order to get the latest patches put out by Red Hat into a CentOS image, you have to add their [Continuous Release (CR) Repository](https://wiki.centos.org/AdditionalResources/Repositories/CR)...and that's just what this PR does.