### PR TITLE
Add recent auth-proxy fixes to v1.12.x branch

### DIFF
--- a/auth-proxy/Dockerfile
+++ b/auth-proxy/Dockerfile
@@ -13,6 +13,7 @@ ENV DL_SITE https://github.com/pingidentity/mod_auth_openidc/releases/download/
 ENV HTTPD_USER apache 
 
 RUN yum install -y epel-release && \
+    yum-config-manager --enable cr && \
     yum update -y && \
     yum install -y hiredis httpd jansson && \
     curl -sL -o /tmp/${CJOSE_PKG} ${DL_SITE}/v${CJOSE_OIDC_VER}/${CJOSE_PKG} && \

--- a/auth-proxy/conf/etc/httpd/conf.d/00-security.conf
+++ b/auth-proxy/conf/etc/httpd/conf.d/00-security.conf
@@ -2,7 +2,7 @@
 # This directive configures what you return as the Server HTTP response
 # Header. The default is 'Full' which sends information about the OS-Type
 # and compiled in modules.
-ServerTokens Minor
+ServerTokens Prod
 
 # Disable TRACE method
 TraceEnable Off

--- a/auth-proxy/conf/etc/httpd/conf/httpd.conf
+++ b/auth-proxy/conf/etc/httpd/conf/httpd.conf
@@ -11,6 +11,19 @@ ServerRoot "/etc/httpd"
 # Load Apache modules
 Include conf.modules.d/*.conf
 
+# Baseline settings
+LimitRequestFieldSize 8190
+LimitRequestLine 8190
+LimitRequestBody 1073741824
+LimitRequestFields 100
+MaxClients 256
+StartServers 3
+KeepAlive On
+KeepAliveTimeout 5
+TimeOut 60
+
+
+
 
 # ServerName gives the name and port that the server uses to identify itself.
 ServerName "localhost"
@@ -24,6 +37,7 @@ Group apache
 # Deny access to the entirety of your server's filesystem.
 <Directory />
     AllowOverride none
+    Options None
     Require all denied
 </Directory>
 
@@ -34,7 +48,10 @@ DocumentRoot "/var/www/html"
 
 # Simple JSON-based status endpoint for /
 <Directory "/var/www/html">
-    Options FollowSymLinks Indexes IncludesNoExec
+    <LimitExcept GET POST OPTIONS>
+        Require all denied
+    </LimitExcept>
+    Options -FollowSymLinks -Indexes +IncludesNoExec -MultiViews
     AddOutputFilter Includes .json
     DirectoryIndex index.json
     AllowOverride None


### PR DESCRIPTION
Adds the recent Apache-related auth-proxy fixups to `v1.12.x` for the upcoming `v1.12.1` patch release.