### PR TITLE
Add Dockerfile for theme-provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:latest
+
+COPY keycloak/themes/hmda /themes

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,26 @@
+podTemplate(label: 'dockerBuild', containers: [
+  containerTemplate(name: 'docker', image: 'docker', ttyEnabled: true, command: 'cat')
+],
+volumes: [
+  hostPathVolume(mountPath: '/var/run/docker.sock', hostPath: '/var/run/docker.sock'),
+]) {
+   node('buildHmdaHelp') {
+     def repo = checkout scm
+     def gitCommit = repo.GIT_COMMIT
+     def gitBranch = repo.GIT_BRANCH
+     def shortGitCommit = "${gitCommit[0..10]}"
+
+    stage('Build And Publish Docker Image') {
+      container('docker') {
+        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'dockerhub',
+            usernameVariable: 'DOCKER_HUB_USER', passwordVariable: 'DOCKER_HUB_PASSWORD']]) {
+              sh "docker build --rm -t=${env.DOCKER_HUB_USER}/theme-provider ."
+              sh "docker tag ${env.DOCKER_HUB_USER}/hmda-help ${env.DOCKER_HUB_USER}/theme-provider:${gitBranch}"
+              sh "docker login -u ${env.DOCKER_HUB_USER} -p ${env.DOCKER_HUB_PASSWORD} "
+              sh "docker push ${env.DOCKER_HUB_USER}/theme-provider:${gitBranch}"
+            }
+        }
+      }
+   }
+
+}


### PR DESCRIPTION
This adds a theme provider image to be used as a init container for a deployment of the latest keycloak image in order to get our custom themes into the image as described in the instructions for the keycloak helm chart here: https://github.com/helm/charts/tree/master/stable/keycloak#providing-a-custom-theme

This PR relates to PR [#2057](https://github.com/cfpb/hmda-platform/pull/2057) on the hmda-platform